### PR TITLE
ReadOnly/Write transactions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ tmpl.go
 /fylrstore
 /commands/server/assets/tmpl.go
 .vscode
+test.db*

--- a/exec.go
+++ b/exec.go
@@ -289,7 +289,6 @@ func (db *DB) InsertBulkCopyIn(table string, data interface{}) error {
 }
 
 func (db *DB) insertStruct(table string, row interface{}) (int64, structInfo, error) {
-
 	values, info, err := db.valuesFromStruct(row)
 	if err != nil {
 		return 0, nil, err
@@ -304,7 +303,6 @@ func (db *DB) insertStruct(table string, row interface{}) (int64, structInfo, er
 		pk := info.onlyPrimaryKey()
 		if pk != nil && pk.structField.Type.Kind() == reflect.Int64 {
 			sql = sql + " RETURNING " + db.Esc(pk.dbName)
-
 			var insert_id int64 = 0
 			err := db.Query(&insert_id, sql, args...)
 			if err != nil {
@@ -561,11 +559,6 @@ func (db *DB) exec(expRows int64, execSql string, args ...interface{}) (int64, e
 	if db.Debug || db.DebugExec {
 		log.Printf("%s SQL: %s\nARGS:\n%s", db, execSql, argsToString(args...))
 	}
-
-	// db.lock()
-	// if db.sqlTx == nil {
-	// 	defer db.unlock()
-	// }
 
 	if len(args) > 0 {
 		execSql0, newArgs, err = db.replaceArgs(execSql, args...)

--- a/query_test.go
+++ b/query_test.go
@@ -103,7 +103,7 @@ func TestMain(m *testing.M) {
 
 	cleanup()
 
-	db, err = Open("sqlite3", "./test.db?_foreign_keys=1&_busy_timeout=1000")
+	db, err = Open("sqlite3", "./test.db?_foreign_keys=1&_journal=wal&_busy_timeout=1000")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/transaction.go
+++ b/transaction.go
@@ -64,14 +64,9 @@ func (db *DB) txBegin(wMode bool) (*DB, error) {
 	return &db2, nil
 }
 
-// Begin starts a new transaction, defaults to write mode
+// Begin starts a new transaction, defaulting to write mode for backwards compatibility
 func (db *DB) Begin() (*DB, error) {
 	return db.txBegin(true)
-}
-
-// BeginWrite starts a new transaction, write mode
-func (db *DB) BeginWrite() (*DB, error) {
-	return db.Begin()
 }
 
 // BeginRead starts a new transaction, read-only mode

--- a/transaction.go
+++ b/transaction.go
@@ -6,9 +6,10 @@ import (
 
 // var transID = 0
 
-// Begin starts a new transaction, this panics if
+// txBegin starts a new transaction, this panics if
 // the wrapper was not initialized using "Open"
-func (db *DB) Begin() (*DB, error) {
+// it gets passed a flag which states if there will be any writes
+func (db *DB) txBegin(wMode bool) (*DB, error) {
 	var (
 		err error
 	)
@@ -22,8 +23,6 @@ func (db *DB) Begin() (*DB, error) {
 
 	db2 := *db
 
-	db2.lock()
-
 	// db2.transID = transID
 	// transID++
 
@@ -32,6 +31,22 @@ func (db *DB) Begin() (*DB, error) {
 	db2.sqlTx, err = db.sqlDB.Begin()
 	if err != nil {
 		return nil, err
+	}
+
+	// If tx starts in write mode, special treatment may be in place
+	if wMode {
+		switch db.Driver {
+
+		// In case of write mode tx for SQLITE driver
+		// There's the need to start it as immediate so it gets a lock
+		// Not implemented in driver, therefore this raw SQL workaround
+		case SQLITE3:
+			log.Printf("%s IMMEDIATE TX: %s sql.DB: %p", db, &db2, db.sqlDB)
+			_, err = db2.sqlTx.Exec("ROLLBACK; BEGIN IMMEDIATE")
+			if err != nil {
+				return nil, err
+			}
+		}
 	}
 	db2.db = db2.sqlTx
 
@@ -46,6 +61,21 @@ func (db *DB) Begin() (*DB, error) {
 	return &db2, nil
 }
 
+// Begin starts a new transaction, defaults to write mode
+func (db *DB) Begin() (*DB, error) {
+	return db.txBegin(true)
+}
+
+// BeginWrite starts a new transaction, write mode
+func (db *DB) BeginWrite() (*DB, error) {
+	return db.Begin()
+}
+
+// BeginRead starts a new transaction, read-only mode
+func (db *DB) BeginRead() (*DB, error) {
+	return db.txBegin(false)
+}
+
 func (db *DB) Commit() error {
 	if db.sqlTx == nil {
 		panic("sqlpro.DB.Commit: Unable to call Commit without Transaction.")
@@ -57,7 +87,6 @@ func (db *DB) Commit() error {
 
 	// pflib.Pln("[%p] COMMIT #%d %s", db.sqlDB, db.transID, aurora.Blue(fmt.Sprintf("%p", db.sqlTx)))
 
-	defer db.unlock()
 	return db.sqlTx.Commit()
 }
 
@@ -73,6 +102,5 @@ func (db *DB) Rollback() error {
 	// debug.PrintStack()
 	// pflib.Pln("[%p] ROLLBACK #%d %s", db.sqlDB, db.transID, aurora.Blue(fmt.Sprintf("%p", db.sqlTx)))
 
-	defer db.unlock()
 	return db.sqlTx.Rollback()
 }

--- a/transaction.go
+++ b/transaction.go
@@ -33,6 +33,9 @@ func (db *DB) txBegin(wMode bool) (*DB, error) {
 		return nil, err
 	}
 
+	// Set flag so we allow or not write operations
+	db2.txWriteMode = wMode
+
 	// If tx starts in write mode, special treatment may be in place
 	if wMode {
 		switch db.Driver {
@@ -41,7 +44,7 @@ func (db *DB) txBegin(wMode bool) (*DB, error) {
 		// There's the need to start it as immediate so it gets a lock
 		// Not implemented in driver, therefore this raw SQL workaround
 		case SQLITE3:
-			log.Printf("%s IMMEDIATE TX: %s sql.DB: %p", db, &db2, db.sqlDB)
+			// log.Printf("%s IMMEDIATE TX: %s sql.DB: %p", db, &db2, db.sqlDB)
 			_, err = db2.sqlTx.Exec("ROLLBACK; BEGIN IMMEDIATE")
 			if err != nil {
 				return nil, err

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -83,7 +83,7 @@ func TestConcurrency(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 
-			db2, err := db.BeginWrite()
+			db2, err := db.Begin()
 			if err != nil {
 				t.Error(err)
 				return

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -133,3 +133,33 @@ func TestConcurrency(t *testing.T) {
 
 	wg.Wait()
 }
+
+func TestReadOnlyMode(t *testing.T) {
+
+	db2, err := db.BeginRead()
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	err = readRow(db2)
+	if err != nil {
+		t.Error(err)
+		db2.Rollback()
+		return
+	}
+
+	err = db2.Insert("test", []*testRow{
+		{
+			B: "readonly",
+			F: jsonStore{"no", "writes"},
+		},
+	})
+	if err == nil {
+		t.Error("Expected error trying to write when a transaction is not in write mode")
+		db2.Rollback()
+		return
+	}
+
+	db2.Commit()
+}

--- a/wrapper.go
+++ b/wrapper.go
@@ -35,6 +35,8 @@ type DB struct {
 	Driver                dbDriver
 	DSN                   string
 
+	txWriteMode           bool
+
 	// transID   int
 	LastError error // This is set to the last error
 }

--- a/wrapper.go
+++ b/wrapper.go
@@ -29,15 +29,12 @@ type DB struct {
 	PlaceholderEscape     rune
 	PlaceholderValue      rune
 	PlaceholderKey        rune
-	UseExecLock           bool
 	MaxPlaceholder        int
 	UseReturningForLastId bool
 	SupportsLastInsertId  bool
 	Driver                dbDriver
 	DSN                   string
 
-	mutexKey  string
-	holdsLock bool
 	// transID   int
 	LastError error // This is set to the last error
 }
@@ -86,7 +83,6 @@ func New(dbWrap dbWrappable) *DB {
 	db.PlaceholderKey = '@'
 	db.DebugExec = false
 	db.MaxPlaceholder = 100
-	db.UseExecLock = true
 	db.SupportsLastInsertId = true
 	db.UseReturningForLastId = false
 


### PR DESCRIPTION
This adds read-only and write transactions creation methods (needed as per SQLite issues)
The original method fallbacks to a write transaction to be backwards compatible
An attempt to write on a read-only transaction will throw an error
Added test for such eventuality and modified test for concurrent transactions